### PR TITLE
Drop support for unmaintained Symfony Versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": ">=7.0",
         "php-ffmpeg/php-ffmpeg": ">=0.11",
-        "symfony/dependency-injection": "^3.0 || ^4.0",
-        "symfony/framework-bundle": "^3.0 || ^4.0"
+        "symfony/dependency-injection": "^3.4 || ^4.3 || ^5.0 ",
+        "symfony/framework-bundle": "^3.4 || ^4.3 || ^5.0 "
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^2.3",


### PR DESCRIPTION
Symfony 5 is also listed, though may fail.