### PR TITLE
Add temporary directory for two-pass logging

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,6 +26,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('ffprobe_binary')->isRequired()->end()
                 ->scalarNode('binary_timeout')->defaultValue(60)->end()
                 ->scalarNode('threads_count')->defaultValue(4)->end()
+                ->scalarNode('temporary_directory')->defaultValue('')->end()
             ->end()
         ->end();
 

--- a/DependencyInjection/DubtureFFmpegExtension.php
+++ b/DependencyInjection/DubtureFFmpegExtension.php
@@ -29,5 +29,6 @@ class DubtureFFmpegExtension extends Extension
         $container->setParameter('dubture_ffprobe.binary', $config['ffprobe_binary']);
         $container->setParameter('dubture_ffmpeg.binary_timeout', $config['binary_timeout']);
         $container->setParameter('dubture_ffmpeg.threads_count', $config['threads_count']);
+        $container->setParameter('dubture_ffmpeg.temporary_directory', $config['temporary_directory']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ dubture_f_fmpeg:
   temporary_directory: /var/ffmpeg-tmp
 ```
 
+> Note: The `temporary_directory` key is only used for writing [two-pass logs](https://ffmpeg.org/ffmpeg.html#Video-Options).
+
 ### Usage
 
 ```php

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ dubture_f_fmpeg:
   ffprobe_binary: /usr/bin/ffprobe
   binary_timeout: 300 # Use 0 for infinite
   threads_count: 4
+  temporary_directory: /var/ffmpeg-tmp
 ```
 
 ### Usage

--- a/Resources/config/factories-2.3.xml
+++ b/Resources/config/factories-2.3.xml
@@ -10,6 +10,7 @@
                 <argument key="ffmpeg.binaries">%dubture_ffmpeg.binary%</argument>
                 <argument key="ffprobe.binaries">%dubture_ffprobe.binary%</argument>
                 <argument key="timeout">%dubture_ffmpeg.binary_timeout%</argument>
+                <argument key="ffmpeg.threads">%dubture_ffmpeg.threads_count%</argument>
                 <argument key="temporary_directory">%dubture_ffmpeg.temporary_directory%</argument>
             </argument>
             <argument id="logger" type="service"/>

--- a/Resources/config/factories-2.3.xml
+++ b/Resources/config/factories-2.3.xml
@@ -10,7 +10,7 @@
                 <argument key="ffmpeg.binaries">%dubture_ffmpeg.binary%</argument>
                 <argument key="ffprobe.binaries">%dubture_ffprobe.binary%</argument>
                 <argument key="timeout">%dubture_ffmpeg.binary_timeout%</argument>
-                <argument key="ffmpeg.threads">%dubture_ffmpeg.threads_count%</argument>
+                <argument key="temporary_directory">%dubture_ffmpeg.temporary_directory%</argument>
             </argument>
             <argument id="logger" type="service"/>
         </service>

--- a/Resources/config/factories.xml
+++ b/Resources/config/factories.xml
@@ -12,6 +12,7 @@
                 <argument key="ffprobe.binaries">%dubture_ffprobe.binary%</argument>
                 <argument key="timeout">%dubture_ffmpeg.binary_timeout%</argument>
                 <argument key="ffmpeg.threads">%dubture_ffmpeg.threads_count%</argument>
+                <argument key="temporary_directory">%dubture_ffmpeg.temporary_directory%</argument>
             </argument>
             <argument id="logger" type="service"/>
         </service>

--- a/Tests/Fixtures/all.yml
+++ b/Tests/Fixtures/all.yml
@@ -3,3 +3,4 @@ dubture_f_fmpeg:
     ffprobe_binary: /usr/local/bin/ffprobe
     binary_timeout: 300
     threads_count: 2
+    temporary_directory: /var/ffmpeg-tmp

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -38,6 +38,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             'ffprobe_binary' => '/usr/local/bin/ffprobe',
             'binary_timeout' => 60,
             'threads_count' => 4,
+            'temporary_directory' => ''
         );
 
         $sources = array(
@@ -57,6 +58,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             'ffprobe_binary' => '/usr/local/bin/ffprobe',
             'binary_timeout' => 300,
             'threads_count' => 2,
+            'temporary_directory' => '/var/ffmpeg-tmp'
         );
 
         $sources = array(

--- a/Tests/Unit/DependencyInjection/DubtureFFmpegExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/DubtureFFmpegExtensionTest.php
@@ -42,6 +42,7 @@ class DubtureFFmpegExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('dubture_ffprobe.binary', '/usr/local/bin/ffprobe');
         $this->assertContainerBuilderHasParameter('dubture_ffmpeg.binary_timeout', 60);
         $this->assertContainerBuilderHasParameter('dubture_ffmpeg.threads_count', 4);
+        $this->assertContainerBuilderHasParameter('dubture_ffmpeg.temporary_directory', '');
     }
 
     public function testAfterLoadingTheFFMpegServiceExists()


### PR DESCRIPTION
Related to [PR 855 PHP-FFMpeg](https://github.com/PHP-FFMpeg/PHP-FFMpeg/pull/855).